### PR TITLE
fix: Scala versions parsing

### DIFF
--- a/src/main/scala/mezel/AspectTypes.scala
+++ b/src/main/scala/mezel/AspectTypes.scala
@@ -30,12 +30,12 @@ object AspectTypes {
       directory: String
   ) derives Decoder
 
-  final case class ScalaVersion(major: Int, minor: Int, patch: Int) {
+  final case class ScalaVersion(major: String, minor: String, patch: String) {
     def toVersion: String = s"${major}.${minor}.${patch}"
   }
   object ScalaVersion {
     given Decoder[ScalaVersion] = Decoder[String].emap { s =>
-      val parts = s.split("\\.").toList.mapFilter(_.toIntOption)
+      val parts = s.split("\\.").toList
       parts match {
         case major :: minor :: patch :: Nil => Right(ScalaVersion(major, minor, patch))
         case _                              => Left(s"invalid scala version: ${s}")

--- a/src/main/scala/mezel/BSPServer.scala
+++ b/src/main/scala/mezel/BSPServer.scala
@@ -600,7 +600,7 @@ class BspServerOps(
       options <- scos.toList.traverse { case (label, sco) =>
         semanticdbCachePath(sco.targetroot).map { semanticdbDir =>
           val semanticDBFlags =
-            if (sco.compilerVersion.major === 2) {
+            if (sco.compilerVersion.major === "2") {
               List(
                 s"-P:semanticdb:targetroot:${semanticdbDir.toString}",
                 "-Xplugin-require:semanticdb",


### PR DESCRIPTION
`Metals` currently supports some RC versions of Scala:

<https://scalameta.org/metals/docs/editors/vscode/#requirements>

But `Mezel` throws an error if we use one of them.